### PR TITLE
Structure Biome Stuff

### DIFF
--- a/src/main/resources/data/datanessence/tags/worldgen/biome/has_structure/abandoned_factory.json
+++ b/src/main/resources/data/datanessence/tags/worldgen/biome/has_structure/abandoned_factory.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+      "#minecraft:is_ocean"
+  ]
+}

--- a/src/main/resources/data/datanessence/tags/worldgen/biome/has_structure/ancient_weapons_facility.json
+++ b/src/main/resources/data/datanessence/tags/worldgen/biome/has_structure/ancient_weapons_facility.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "#minecraft:spawns_snow_foxes"
+    ]
+}

--- a/src/main/resources/data/datanessence/tags/worldgen/biome/has_structure/arekkos_vault.json
+++ b/src/main/resources/data/datanessence/tags/worldgen/biome/has_structure/arekkos_vault.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "#minecraft:is_mountain"
+  ]
+}

--- a/src/main/resources/data/datanessence/tags/worldgen/biome/has_structure/failed_pylon.json
+++ b/src/main/resources/data/datanessence/tags/worldgen/biome/has_structure/failed_pylon.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "#minecraft:has_structure/pillager_outpost"
+  ]
+}

--- a/src/main/resources/data/datanessence/tags/worldgen/biome/has_structure/outpost_nature.json
+++ b/src/main/resources/data/datanessence/tags/worldgen/biome/has_structure/outpost_nature.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "#minecraft:has_structure/jungle_temple"
+    ]
+}

--- a/src/main/resources/data/datanessence/worldgen/structure/abandoned_factory.json
+++ b/src/main/resources/data/datanessence/worldgen/structure/abandoned_factory.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft:jigsaw",
-  "biomes": "#minecraft:is_ocean",
+  "biomes": "#datanessence:has_structure/abandoned_factory",
   "step": "surface_structures",
   "spawn_overrides": {},
   "terrain_adaptation": "none",

--- a/src/main/resources/data/datanessence/worldgen/structure/ancient_weapons_facility.json
+++ b/src/main/resources/data/datanessence/worldgen/structure/ancient_weapons_facility.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft:jigsaw",
-  "biomes": "#minecraft:has_structure/igloo",
+  "biomes": "#datanessence:has_structure/ancient_weapons_facility",
   "step": "surface_structures",
   "spawn_overrides": {},
   "terrain_adaptation": "none",

--- a/src/main/resources/data/datanessence/worldgen/structure/arekkos_vault.json
+++ b/src/main/resources/data/datanessence/worldgen/structure/arekkos_vault.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft:jigsaw",
-  "biomes": "#minecraft:is_mountain",
+  "biomes": "#datanessence:has_structure/arekkos_vault",
   "step": "surface_structures",
   "spawn_overrides": {},
   "terrain_adaptation": "beard_thin",

--- a/src/main/resources/data/datanessence/worldgen/structure/failed_pylon.json
+++ b/src/main/resources/data/datanessence/worldgen/structure/failed_pylon.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft:jigsaw",
-  "biomes": "#minecraft:has_structure/pillager_outpost",
+  "biomes": "#datanessence:has_structure/failed_pylon",
   "step": "surface_structures",
   "spawn_overrides": {},
   "terrain_adaptation": "beard_thin",

--- a/src/main/resources/data/datanessence/worldgen/structure/outpost_nature.json
+++ b/src/main/resources/data/datanessence/worldgen/structure/outpost_nature.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft:jigsaw",
-  "biomes": "#minecraft:has_structure/jungle_temple",
+  "biomes": "#datanessence:has_structure/outpost_nature",
   "step": "surface_structures",
   "spawn_overrides": {},
   "terrain_adaptation": "beard_thin",


### PR DESCRIPTION
Switch to `has_structure` tags and broaden Ancient Weapons Facility spawn biomes

Ancient Weapons Facility previously used `has_structure/igloo` which only contains
- minecraft:snowy_plains
- minecraft:snowy_slopes
- minecraft:snowy_taiga

It now uses `spawns_snow_foxes` which contains
- minecraft:frozen_ocean
- minecraft:frozen_peaks
- minecraft:frozen_river
- minecraft:grove
- minecraft:ice_spikes
- minecraft:jagged_peaks
- minecraft:snowy_beach
- minecraft:snowy_plains
- minecraft:snowy_slopes
- minecraft:snowy_taiga