### PR TITLE
[Sable Compat] fix "[Sable Compat] fix wire rendering for points on sable sublevels"

### DIFF
--- a/src/main/java/EsetKalenko/Halcyon/api/node/renderers/BaseCapabilityPointRenderer.java
+++ b/src/main/java/EsetKalenko/Halcyon/api/node/renderers/BaseCapabilityPointRenderer.java
@@ -47,27 +47,24 @@ public abstract class BaseCapabilityPointRenderer<T extends BaseCapabilityPointB
     @Override
     public void render(T pBlockEntity, float pPartialTick, PoseStack pPoseStack, MultiBufferSource pBufferSource, int pPackedLight, int pPackedOverlay) {
         if (pBlockEntity.link != null) {
-            BlockPos blockPos = ClientRenderingUtil.getGlobalPos(pBlockEntity.getLevel(), pBlockEntity.getBlockPos());
-            Vec3 pos = blockPos.getCenter();
+            BlockPos blockPos = pBlockEntity.getBlockPos();
             pPoseStack.pushPose();
-            pPoseStack.translate(-pos.x, -pos.y, -pos.z);
             pPoseStack.translate(0.5, 0.5, 0.5);
             Vec3 origin = blockPos.getCenter();
             for (BlockPos i : pBlockEntity.link) {
-                BlockPos targetBlockPos = ClientRenderingUtil.getGlobalPos(pBlockEntity.getLevel(), i);
-                Vec3 target = targetBlockPos.getCenter();
+                Vec3 target = i.getCenter();
                 VertexConsumer vertexConsumer = RenderHandler.createBufferSource().getBuffer(DataNEssenceRenderTypes.WIRES);
                 Color segColor1 = pBlockEntity.linkColor()[0];
                 Color segColor2 = pBlockEntity.linkColor()[1];
                 Color segColor3 = ColorUtil.blendColors(segColor1, segColor2, 0.35f);
                 float ticks = (Minecraft.getInstance().level.getGameTime() % 8)+pPartialTick;
                 int currentSeg = (int)(ticks % 8);
-                ClientRenderingUtil.renderLine(vertexConsumer, pPoseStack, origin, target, (seg) -> {
+                ClientRenderingUtil.renderLine(vertexConsumer, pPoseStack, Vec3.ZERO, target.subtract(origin), (seg) -> {
                     if (7-(seg % 8) == getSegWithOffset(currentSeg, -2) || 7-(seg % 8) == getSegWithOffset(currentSeg, 1) % 8) {
                         return segColor3;
                     }
                     return 7-(seg % 8) == currentSeg || 7-(seg % 8) == getSegWithOffset(currentSeg, -1) ? segColor1 : segColor2;
-                }, blockPos.getX() == targetBlockPos.getX() && blockPos.getZ() == targetBlockPos.getZ() ? 0 : 0.3);
+                }, blockPos.getX() == i.getX() && blockPos.getZ() == i.getZ() ? 0 : 0.3);
             }
             pPoseStack.popPose();
         }

--- a/src/main/java/EsetKalenko/Halcyon/api/node/renderers/BaseCapabilityPointRenderer.java
+++ b/src/main/java/EsetKalenko/Halcyon/api/node/renderers/BaseCapabilityPointRenderer.java
@@ -15,6 +15,8 @@ import EsetKalenko.Halcyon.client.shaders.DataNEssenceRenderTypes;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
+import dev.ryanhcode.sable.companion.ClientSubLevelAccess;
+import dev.ryanhcode.sable.companion.SableCompanion;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -25,6 +27,8 @@ import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.level.block.state.properties.AttachFace;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+import org.joml.Quaterniondc;
+import org.joml.Quaternionf;
 
 import java.awt.*;
 
@@ -50,21 +54,30 @@ public abstract class BaseCapabilityPointRenderer<T extends BaseCapabilityPointB
             BlockPos blockPos = pBlockEntity.getBlockPos();
             pPoseStack.pushPose();
             pPoseStack.translate(0.5, 0.5, 0.5);
-            Vec3 origin = blockPos.getCenter();
+
+            ClientSubLevelAccess sublevel = SableCompanion.INSTANCE.getContainingClient(blockPos);
+            if (sublevel != null) {
+                Quaterniondc sublevelOrientation = sublevel.renderPose().orientation();
+                Quaternionf worldOrientation = sublevelOrientation.get(new Quaternionf()).conjugate();
+                pPoseStack.mulPose(worldOrientation);
+            }
+            Vec3 origin = ClientRenderingUtil.transformPosition(blockPos.getCenter());
+
+            pPoseStack.translate(-origin.x, -origin.y, -origin.z);
             for (BlockPos i : pBlockEntity.link) {
-                Vec3 target = i.getCenter();
+                Vec3 target = ClientRenderingUtil.transformPosition(i.getCenter());
                 VertexConsumer vertexConsumer = RenderHandler.createBufferSource().getBuffer(DataNEssenceRenderTypes.WIRES);
                 Color segColor1 = pBlockEntity.linkColor()[0];
                 Color segColor2 = pBlockEntity.linkColor()[1];
                 Color segColor3 = ColorUtil.blendColors(segColor1, segColor2, 0.35f);
                 float ticks = (Minecraft.getInstance().level.getGameTime() % 8)+pPartialTick;
                 int currentSeg = (int)(ticks % 8);
-                ClientRenderingUtil.renderLine(vertexConsumer, pPoseStack, Vec3.ZERO, target.subtract(origin), (seg) -> {
+                ClientRenderingUtil.renderLine(vertexConsumer, pPoseStack, origin, target, (seg) -> {
                     if (7-(seg % 8) == getSegWithOffset(currentSeg, -2) || 7-(seg % 8) == getSegWithOffset(currentSeg, 1) % 8) {
                         return segColor3;
                     }
                     return 7-(seg % 8) == currentSeg || 7-(seg % 8) == getSegWithOffset(currentSeg, -1) ? segColor1 : segColor2;
-                }, blockPos.getX() == i.getX() && blockPos.getZ() == i.getZ() ? 0 : 0.3);
+                }, target.subtract(origin).horizontalDistance() < 0.3 ? 0 : 0.3);
             }
             pPoseStack.popPose();
         }

--- a/src/main/java/EsetKalenko/Halcyon/api/node/renderers/BaseEssencePointRenderer.java
+++ b/src/main/java/EsetKalenko/Halcyon/api/node/renderers/BaseEssencePointRenderer.java
@@ -14,6 +14,8 @@ import EsetKalenko.Halcyon.api.node.block.BaseEssencePointBlockEntity;
 import EsetKalenko.Halcyon.client.shaders.DataNEssenceRenderTypes;
 import com.mojang.blaze3d.vertex.*;
 import com.mojang.math.Axis;
+import dev.ryanhcode.sable.companion.ClientSubLevelAccess;
+import dev.ryanhcode.sable.companion.SableCompanion;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -24,6 +26,8 @@ import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.level.block.state.properties.AttachFace;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+import org.joml.Quaterniondc;
+import org.joml.Quaternionf;
 
 import java.awt.*;
 
@@ -47,24 +51,32 @@ public abstract class BaseEssencePointRenderer<T extends BaseEssencePointBlockEn
     public void render(T pBlockEntity, float pPartialTick, PoseStack pPoseStack, MultiBufferSource pBufferSource, int pPackedLight, int pPackedOverlay) {
         if (pBlockEntity.link != null) {
             BlockPos blockPos = pBlockEntity.getBlockPos();
-            Vec3 pos = blockPos.getCenter();
             pPoseStack.pushPose();
             pPoseStack.translate(0.5, 0.5, 0.5);
-            Vec3 origin = blockPos.getCenter();
+
+            ClientSubLevelAccess sublevel = SableCompanion.INSTANCE.getContainingClient(blockPos);
+            if (sublevel != null) {
+                Quaterniondc sublevelOrientation = sublevel.renderPose().orientation();
+                Quaternionf worldOrientation = sublevelOrientation.get(new Quaternionf()).conjugate();
+                pPoseStack.mulPose(worldOrientation);
+            }
+            Vec3 origin = ClientRenderingUtil.transformPosition(blockPos.getCenter());
+
+            pPoseStack.translate(-origin.x, -origin.y, -origin.z);
             for (BlockPos i : pBlockEntity.link) {
-                Vec3 target = i.getCenter();
+                Vec3 target = ClientRenderingUtil.transformPosition(i.getCenter());
                 VertexConsumer vertexConsumer = RenderHandler.createBufferSource().getBuffer(DataNEssenceRenderTypes.WIRES);
                 Color segColor1 = pBlockEntity.linkColor()[0];
                 Color segColor2 = pBlockEntity.linkColor()[1];
                 Color segColor3 = ColorUtil.blendColors(segColor1, segColor2, 0.35f);
                 float ticks = (Minecraft.getInstance().level.getGameTime() % 8)+pPartialTick;
                 int currentSeg = (int)(ticks % 8);
-                ClientRenderingUtil.renderLine(vertexConsumer, pPoseStack, Vec3.ZERO, target.subtract(origin), (seg) -> {
+                ClientRenderingUtil.renderLine(vertexConsumer, pPoseStack, origin, target, (seg) -> {
                     if (7-(seg % 8) == getSegWithOffset(currentSeg, -2) || 7-(seg % 8) == getSegWithOffset(currentSeg, 1) % 8) {
                         return segColor3;
                     }
                     return 7-(seg % 8) == currentSeg || 7-(seg % 8) == getSegWithOffset(currentSeg, -1) ? segColor1 : segColor2;
-                }, blockPos.getX() == i.getX() && blockPos.getZ() == i.getZ() ? 0 : 0.3);
+                }, target.subtract(origin).horizontalDistance() < 0.3 ? 0 : 0.3);
             }
             pPoseStack.popPose();
         }

--- a/src/main/java/EsetKalenko/Halcyon/api/node/renderers/BaseEssencePointRenderer.java
+++ b/src/main/java/EsetKalenko/Halcyon/api/node/renderers/BaseEssencePointRenderer.java
@@ -46,27 +46,25 @@ public abstract class BaseEssencePointRenderer<T extends BaseEssencePointBlockEn
     @Override
     public void render(T pBlockEntity, float pPartialTick, PoseStack pPoseStack, MultiBufferSource pBufferSource, int pPackedLight, int pPackedOverlay) {
         if (pBlockEntity.link != null) {
-            BlockPos blockPos = ClientRenderingUtil.getGlobalPos(pBlockEntity.getLevel(), pBlockEntity.getBlockPos());
+            BlockPos blockPos = pBlockEntity.getBlockPos();
             Vec3 pos = blockPos.getCenter();
             pPoseStack.pushPose();
-            pPoseStack.translate(-pos.x, -pos.y, -pos.z);
             pPoseStack.translate(0.5, 0.5, 0.5);
             Vec3 origin = blockPos.getCenter();
             for (BlockPos i : pBlockEntity.link) {
-                BlockPos targetBlockPos = ClientRenderingUtil.getGlobalPos(pBlockEntity.getLevel(), i);
-                Vec3 target = targetBlockPos.getCenter();
+                Vec3 target = i.getCenter();
                 VertexConsumer vertexConsumer = RenderHandler.createBufferSource().getBuffer(DataNEssenceRenderTypes.WIRES);
                 Color segColor1 = pBlockEntity.linkColor()[0];
                 Color segColor2 = pBlockEntity.linkColor()[1];
                 Color segColor3 = ColorUtil.blendColors(segColor1, segColor2, 0.35f);
                 float ticks = (Minecraft.getInstance().level.getGameTime() % 8)+pPartialTick;
                 int currentSeg = (int)(ticks % 8);
-                ClientRenderingUtil.renderLine(vertexConsumer, pPoseStack, origin, target, (seg) -> {
+                ClientRenderingUtil.renderLine(vertexConsumer, pPoseStack, Vec3.ZERO, target.subtract(origin), (seg) -> {
                     if (7-(seg % 8) == getSegWithOffset(currentSeg, -2) || 7-(seg % 8) == getSegWithOffset(currentSeg, 1) % 8) {
                         return segColor3;
                     }
                     return 7-(seg % 8) == currentSeg || 7-(seg % 8) == getSegWithOffset(currentSeg, -1) ? segColor1 : segColor2;
-                }, blockPos.getX() == targetBlockPos.getX() && blockPos.getZ() == targetBlockPos.getZ() ? 0 : 0.3);
+                }, blockPos.getX() == i.getX() && blockPos.getZ() == i.getZ() ? 0 : 0.3);
             }
             pPoseStack.popPose();
         }

--- a/src/main/java/EsetKalenko/Halcyon/api/util/client/ClientRenderingUtil.java
+++ b/src/main/java/EsetKalenko/Halcyon/api/util/client/ClientRenderingUtil.java
@@ -6,6 +6,8 @@ import EsetKalenko.Halcyon.client.shaders.DataNEssenceCoreShaders;
 import EsetKalenko.Halcyon.client.shaders.DataNEssenceRenderTypes;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import dev.ryanhcode.sable.companion.ClientSubLevelAccess;
+import dev.ryanhcode.sable.companion.SableCompanion;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -112,7 +114,7 @@ public class ClientRenderingUtil extends ClientProgressionUtil {
             double startLerp = getFractionalLerp(i, segmentCount - 1);
             double startYLerp = getYLerp(startLerp, diff.y);
             double sagFactor = sag * (1 - (4 * Math.pow(startLerp - 0.5, 2)));
-            double y = diff.y != 0 ? (startYLerp - sagFactor) * diff.y : -sagFactor;
+            double y = (startYLerp - sagFactor) * diff.y - sagFactor;
             segments.add(new Vec3(startLerp * diff.x, y, startLerp * diff.z).add(sagOrigin));
         }
         if (!segments.isEmpty()) {
@@ -129,5 +131,10 @@ public class ClientRenderingUtil extends ClientProgressionUtil {
     }
     public static Vector3f parametricSphere(float u, float v, float r) {
         return new Vector3f(Mth.cos(u) * Mth.sin(v) * r, Mth.cos(v) * r, Mth.sin(u) * Mth.sin(v) * r);
+    }
+    public static Vec3 transformPosition(Vec3 pos) {
+        ClientSubLevelAccess sublevel = SableCompanion.INSTANCE.getContainingClient(pos);
+        if (sublevel == null) return pos;
+        return sublevel.renderPose().transformPosition(pos);
     }
 }

--- a/src/main/java/EsetKalenko/Halcyon/api/util/client/ClientRenderingUtil.java
+++ b/src/main/java/EsetKalenko/Halcyon/api/util/client/ClientRenderingUtil.java
@@ -6,18 +6,13 @@ import EsetKalenko.Halcyon.client.shaders.DataNEssenceCoreShaders;
 import EsetKalenko.Halcyon.client.shaders.DataNEssenceRenderTypes;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
-import dev.ryanhcode.sable.companion.SableCompanion;
-import dev.ryanhcode.sable.companion.SubLevelAccess;
-import dev.ryanhcode.sable.companion.math.Pose3dc;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.ShaderInstance;
-import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
 import net.minecraft.util.Mth;
 import net.minecraft.world.inventory.Slot;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.items.SlotItemHandler;
 import org.joml.Matrix4f;
@@ -134,21 +129,5 @@ public class ClientRenderingUtil extends ClientProgressionUtil {
     }
     public static Vector3f parametricSphere(float u, float v, float r) {
         return new Vector3f(Mth.cos(u) * Mth.sin(v) * r, Mth.cos(v) * r, Mth.sin(u) * Mth.sin(v) * r);
-    }
-
-    public static Vec3 getGlobalPos(Level level, Vec3 pos) {
-        if (level == null) return pos;
-        SubLevelAccess sublevel = SableCompanion.INSTANCE.getContaining(level, pos);
-        if (sublevel == null) return pos;
-        Pose3dc pose = sublevel.logicalPose();
-        return pose.transformPosition(pos);
-    }
-    public static BlockPos getGlobalPos(Level level, BlockPos pos) {
-        if (level == null) return pos;
-        SubLevelAccess sublevel = SableCompanion.INSTANCE.getContaining(level, pos);
-        if (sublevel == null) return pos;
-        Pose3dc pose = sublevel.logicalPose();
-        Vec3 globalPos = pose.transformPosition(pos.getCenter());
-        return BlockPos.containing(globalPos);
     }
 }

--- a/src/main/java/EsetKalenko/Halcyon/client/ClientEvents.java
+++ b/src/main/java/EsetKalenko/Halcyon/client/ClientEvents.java
@@ -113,9 +113,11 @@ public class ClientEvents {
             if (ClientPlayerData.getLinkPos() != null) {
                 BlockEntity blockEntity = mc.level.getBlockEntity(ClientPlayerData.getLinkPos());
                 Vec3 pos = event.getCamera().getPosition();
-                Vec3 pos1 = ClientPlayerData.getLinkPos().getCenter().subtract(pos);
-                Vec3 pos2 = mc.player.getRopeHoldPosition(event.getPartialTick().getGameTimeDeltaPartialTick(true)).subtract(pos);
+                Vec3 pos1 = ClientRenderingUtil.transformPosition(ClientPlayerData.getLinkPos().getCenter());
+                Vec3 pos2 = mc.player.getRopeHoldPosition(event.getPartialTick().getGameTimeDeltaPartialTick(true));
                 Color color = ClientPlayerData.getLinkColor();
+                event.getPoseStack().pushPose();
+                event.getPoseStack().translate(-pos.x, -pos.y, -pos.z);
                 if (blockEntity instanceof PearlNetworkBlockEntity ent) {
                     Vec3 currentPos = pos1;
                     Vec3 target = pos2;
@@ -127,6 +129,7 @@ public class ClientEvents {
                 } else {
                     ClientRenderingUtil.renderLine(bufferSource.getBuffer(DataNEssenceRenderTypes.WIRES), event.getPoseStack(), pos1, pos2, color);
                 }
+                event.getPoseStack().popPose();
             }
             for (Player i : mc.level.players()) {
                 GrapplingHook.GrapplingHookData grapplingHookData = i.getData(AttachmentTypeRegistry.GRAPPLING_HOOK_DATA).orElse(null);

--- a/src/main/java/EsetKalenko/Halcyon/client/ClientEvents.java
+++ b/src/main/java/EsetKalenko/Halcyon/client/ClientEvents.java
@@ -113,11 +113,9 @@ public class ClientEvents {
             if (ClientPlayerData.getLinkPos() != null) {
                 BlockEntity blockEntity = mc.level.getBlockEntity(ClientPlayerData.getLinkPos());
                 Vec3 pos = event.getCamera().getPosition();
-                Vec3 pos1 = ClientRenderingUtil.getGlobalPos(mc.level, ClientPlayerData.getLinkPos().getCenter());
-                Vec3 pos2 = mc.player.getRopeHoldPosition(event.getPartialTick().getGameTimeDeltaPartialTick(true));
+                Vec3 pos1 = ClientPlayerData.getLinkPos().getCenter().subtract(pos);
+                Vec3 pos2 = mc.player.getRopeHoldPosition(event.getPartialTick().getGameTimeDeltaPartialTick(true)).subtract(pos);
                 Color color = ClientPlayerData.getLinkColor();
-                event.getPoseStack().pushPose();
-                event.getPoseStack().translate(-pos.x, -pos.y, -pos.z);
                 if (blockEntity instanceof PearlNetworkBlockEntity ent) {
                     Vec3 currentPos = pos1;
                     Vec3 target = pos2;
@@ -129,7 +127,6 @@ public class ClientEvents {
                 } else {
                     ClientRenderingUtil.renderLine(bufferSource.getBuffer(DataNEssenceRenderTypes.WIRES), event.getPoseStack(), pos1, pos2, color);
                 }
-                event.getPoseStack().popPose();
             }
             for (Player i : mc.level.players()) {
                 GrapplingHook.GrapplingHookData grapplingHookData = i.getData(AttachmentTypeRegistry.GRAPPLING_HOOK_DATA).orElse(null);


### PR DESCRIPTION
- wire rendering now accounts for sublevel orientation (oops!!!)
- wires will now sag downwards even if sublevel is oriented differently
- wire sagging formula has been modified slightly to prevent discontinuity when a sublevel is rotating vertically